### PR TITLE
feat: Flesh out all specifications using Switch

### DIFF
--- a/src/itksn/core.py
+++ b/src/itksn/core.py
@@ -1,4 +1,13 @@
-from construct import Enum, Struct, Bytes, EnumIntegerString, Switch, this, Const, Terminated
+from construct import (
+    Enum,
+    Struct,
+    Bytes,
+    EnumIntegerString,
+    Switch,
+    this,
+    Const,
+    Terminated,
+)
 
 
 class EnumStr(Enum):

--- a/src/itksn/core.py
+++ b/src/itksn/core.py
@@ -1,4 +1,4 @@
-from construct import Enum, Struct, Bytes, EnumIntegerString
+from construct import Enum, Struct, Bytes, EnumIntegerString, Switch, this, Const
 
 
 class EnumStr(Enum):
@@ -8,6 +8,91 @@ class EnumStr(Enum):
         except KeyError:
             return EnumIntegerString.new(obj, "")
 
+
+fe_chip_version = EnumStr(
+    Bytes(1),
+    RD53A=b"0",
+    ITkpix_v1=b"1",
+    ITkpix_v1p1=b"2",
+    ITkpix_v2=b"3",
+)
+
+fe_chip_wafer = Struct(
+    "batch_number"
+    / EnumStr(
+        Bytes(1),
+        RD53A=b"0",
+        ITkpix_v1=b"1",
+        CROC=b"2",
+    ),
+    "number" / Bytes(6),
+)
+
+sensor = Struct(
+    "manufacturer"
+    / EnumStr(Bytes(1), V1=b"0", V2=b"1", V3=b"2", V4=b"3", V5=b"4", V6=b"5"),
+    "sensor_type"
+    / EnumStr(
+        Bytes(1),
+        Single_RD53A=b"0",
+        Single_ITkpix_v1_2=b"1",
+        Double=b"2",
+        Quad=b"3",
+        Test_Structure_1=b"4",
+        Test_Structure_2=b"5",
+        Test_Structure_3=b"6",
+        Test_Structure_4=b"7",
+        Test_Structure_5=b"8",
+        Test_Structure_6=b"9",
+    ),
+    "number" / Bytes(5),
+)
+
+bare_module = Struct(
+    "FE_chip_version" / fe_chip_version,
+    "sensor_type"
+    / EnumStr(
+        Bytes(1),
+        No_sensor=b"0",
+        Market_survey_sensor_tile=b"1",
+        L0_inner_pixel_3D_sensor_tile=b"2",
+        L0_inner_pixel_planar_sensor_tile=b"3",
+        L1_inner_pixel_quad_sensor_tile=b"4",
+        Outer_pixel_quad_sensor_tile=b"5",
+    ),
+    "number" / Bytes(5),
+)
+
+pcb = Struct(
+    "FE_chip_version" / fe_chip_version,
+    "reserved" / Const(b"0"),
+    "number" / Bytes(5),
+)
+
+module = Struct(
+    "FE_chip_version" / fe_chip_version,
+    "reserved" / Const(b"0"),
+    "number" / Bytes(5),
+)
+
+module_carrier = Struct(
+    "module_type"
+    / EnumStr(
+        Bytes(1),
+        Quad_module_carrier=b"0",
+        Cell_loaded_quad_module_bottom_cover=b"1",
+        Linear_triplet_module_carrier=b"2",
+        Ring_triplet_module_carrier=b"3",
+    ),
+    "module_version"
+    / EnumStr(
+        Bytes(1),
+        Triplet_v1p0=b"1",
+        Quad_v2p1=b"2",
+    ),
+    "manufacturer" / Bytes(1),
+    "number" / Bytes(4),
+)
 
 SerialNumberStruct = "SerialNumber" / Struct(
     "atlas_project" / EnumStr(Bytes(2), atlas_detector=b"20"),
@@ -29,6 +114,88 @@ SerialNumberStruct = "SerialNumber" / Struct(
         common_mechanics=b"CM",
         common_electronics=b"CE",
     ),
-    "subproject_code" / Bytes(2),
-    "identifier" / Bytes(7),
+    "subproject_code"
+    / EnumStr(
+        Bytes(2),
+        FE_chip_wafer=b"FW",
+        FE_chip=b"FC",
+        Market_Survey_sensor_wafer=b"WM",
+        L0_inner_pixel_3D_sensor_wafer=b"W0",
+        L0_inner_pixel_planar_sensor_wafer=b"W1",
+        L1_inner_pixel_sensor_wafer_thickness_100mum=b"W2",
+        Outer_pixel_sensor_wafer_thickness_150mum=b"W3",
+        Dummy_sensor_wafer=b"WD",
+        Market_survey_sensor_tile=b"SM",
+        L0_inner_pixel_3D_sensor_tile=b"S0",
+        L0_inner_pixel_planar_sensor_tile=b"S1",
+        L1_inner_pixel_quad_sensor_tile=b"S2",
+        Outer_pixel_quad_sensor_tile=b"S3",
+        Single_bare_module=b"B1",
+        Dual_bare_module=b"B2",
+        Quad_bare_module=b"B4",
+        Digital_single_bare_module=b"BS",
+        Digital_quad_bare_module=b"BQ",
+        Dummy_single_bare_module=b"BT",
+        Dummy_quad_bare_module=b"BR",
+        Triplet_L0_Stave_PCB=b"PT",
+        Triplet_L0_R0_PCB=b"P0",
+        Triplet_L0_R0p5_PCB=b"P5",
+        Quad_PCB=b"PQ",
+        Dual_PCB=b"PD",
+        PCB_test_coupon=b"PC",
+        Triplet_L0_stave_module=b"MS",
+        Triplet_L0_Ring0_module=b"M0",
+        Triplet_L0_Ring0p5_module=b"M5",
+        L1_quad_module=b"M1",
+        Outer_system_quad_module=b"M2",
+        Dual_chip_module=b"R2",
+        Digital_triplet_module=b"R3",
+        Digital_quad_module=b"R4",
+        Dummy_triplet_module=b"R0",
+        Dummy_quad_module=b"R1",
+        Module_carrier=b"MC",
+    ),
+    "identifier"
+    / Switch(
+        this.subproject_code,
+        {
+            "FE_chip_wafer": fe_chip_wafer,
+            "Market_Survey_sensor_wafer": sensor,
+            "L0_inner_pixel_3D_sensor_wafer": sensor,
+            "L0_inner_pixel_planar_sensor_wafer": sensor,
+            "L1_inner_pixel_sensor_wafer_thickness_100mum": sensor,
+            "Outer_pixel_sensor_wafer_thickness_150mum": sensor,
+            "Dummy_sensor_wafer": sensor,
+            "Market_survey_sensor_tile": sensor,
+            "L0_inner_pixel_3D_sensor_tile": sensor,
+            "L0_inner_pixel_planar_sensor_tile": sensor,
+            "L1_inner_pixel_quad_sensor_tile": sensor,
+            "Outer_pixel_quad_sensor_tile": sensor,
+            "Single_bare_module": bare_module,
+            "Dual_bare_module": bare_module,
+            "Quad_bare_module": bare_module,
+            "Digital_single_bare_module": bare_module,
+            "Digital_quad_bare_module": bare_module,
+            "Dummy_single_bare_module": bare_module,
+            "Dummy_quad_bare_module": bare_module,
+            "Triplet_L0_Stave_PCB": pcb,
+            "Triplet_L0_R0_PCB": pcb,
+            "Triplet_L0_R0p5_PCB": pcb,
+            "Quad_PCB": pcb,
+            "Dual_PCB": pcb,
+            "PCB_test_coupon": pcb,
+            "Triplet_L0_stave_module": module,
+            "Triplet_L0_Ring0_module": module,
+            "Triplet_L0_Ring0p5_module": module,
+            "L1_quad_module": module,
+            "Outer_system_quad_module": module,
+            "Dual_chip_module": module,
+            "Digital_triplet_module": module,
+            "Digital_quad_module": module,
+            "Dummy_triplet_module": module,
+            "Dummy_quad_module": module,
+            "Module_carrier": module_carrier,
+        },
+        default=Bytes(7),
+    ),
 )

--- a/src/itksn/core.py
+++ b/src/itksn/core.py
@@ -1,4 +1,4 @@
-from construct import Enum, Struct, Bytes, EnumIntegerString, Switch, this, Const
+from construct import Enum, Struct, Bytes, EnumIntegerString, Switch, this, Const, Terminated
 
 
 class EnumStr(Enum):
@@ -198,4 +198,5 @@ SerialNumberStruct = "SerialNumber" / Struct(
         },
         default=Bytes(7),
     ),
+    Terminated,
 )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,8 @@
+import pytest
+from construct import Bytes
+from construct.core import TerminatedError
 import itksn
 from itksn.core import EnumStr
-from construct import Bytes
 
 
 def test_enumstr():
@@ -16,7 +18,7 @@ def test_parse_example1():
     assert parsed.atlas_project == "atlas_detector"
     assert parsed.system_code == "phaseII_upgrade"
     assert parsed.project_code == ""
-    assert parsed.subproject_code == b"yy"
+    assert parsed.subproject_code == ""
     assert parsed.identifier == b"nnnnnnn"
 
 
@@ -25,5 +27,76 @@ def test_parse_example2():
     assert parsed.atlas_project == "atlas_detector"
     assert parsed.system_code == "phaseII_upgrade"
     assert parsed.project_code == "inner_pixel"
-    assert parsed.subproject_code == b"yy"
+    assert parsed.subproject_code == ""
     assert parsed.identifier == b"nnnnnnn"
+
+
+def test_parse_fe_wafer():
+    parsed = itksn.parse(b"20UPGFW2123456")
+    assert parsed.atlas_project == "atlas_detector"
+    assert parsed.system_code == "phaseII_upgrade"
+    assert parsed.project_code == "pixel_general"
+    assert parsed.subproject_code == "FE_chip_wafer"
+    assert parsed.identifier.batch_number == "CROC"
+    assert parsed.identifier.number == b"123456"
+
+
+def test_parse_sensor():
+    parsed = itksn.parse(b"20UPGW34212345")
+    assert parsed.atlas_project == "atlas_detector"
+    assert parsed.system_code == "phaseII_upgrade"
+    assert parsed.project_code == "pixel_general"
+    assert parsed.subproject_code == "Outer_pixel_sensor_wafer_thickness_150mum"
+    assert parsed.identifier.manufacturer == "V5"
+    assert parsed.identifier.sensor_type == "Double"
+    assert parsed.identifier.number == b"12345"
+
+
+def test_parse_bare_module():
+    parsed = itksn.parse(b"20UPGBS1112345")
+    assert parsed.atlas_project == "atlas_detector"
+    assert parsed.system_code == "phaseII_upgrade"
+    assert parsed.project_code == "pixel_general"
+    assert parsed.subproject_code == "Digital_single_bare_module"
+    assert parsed.identifier.FE_chip_version == "ITkpix_v1"
+    assert parsed.identifier.sensor_type == "Market_survey_sensor_tile"
+    assert parsed.identifier.number == b"12345"
+
+
+def test_parse_pcb():
+    parsed = itksn.parse(b"20UPGPD0012345")
+    assert parsed.atlas_project == "atlas_detector"
+    assert parsed.system_code == "phaseII_upgrade"
+    assert parsed.project_code == "pixel_general"
+    assert parsed.subproject_code == "Dual_PCB"
+    assert parsed.identifier.FE_chip_version == "RD53A"
+    assert parsed.identifier.reserved == b"0"
+    assert parsed.identifier.number == b"12345"
+
+
+def test_parse_module():
+    parsed = itksn.parse(b"20UPGR40012345")
+    assert parsed.atlas_project == "atlas_detector"
+    assert parsed.system_code == "phaseII_upgrade"
+    assert parsed.project_code == "pixel_general"
+    assert parsed.subproject_code == "Digital_quad_module"
+    assert parsed.identifier.FE_chip_version == "RD53A"
+    assert parsed.identifier.reserved == b"0"
+    assert parsed.identifier.number == b"12345"
+
+
+def test_parse_module_carrier():
+    parsed = itksn.parse(b"20UPGMC2291234")
+    assert parsed.atlas_project == "atlas_detector"
+    assert parsed.system_code == "phaseII_upgrade"
+    assert parsed.project_code == "pixel_general"
+    assert parsed.subproject_code == "Module_carrier"
+    assert parsed.identifier.module_type == "Linear_triplet_module_carrier"
+    assert parsed.identifier.module_version == "Quad_v2p1"
+    assert parsed.identifier.manufacturer == b"9"
+    assert parsed.identifier.number == b"1234"
+
+
+def test_parse_toomany():
+    with pytest.raises(TerminatedError):
+        itksn.parse(b"20Uxxyynnnnnnnmmmm")


### PR DESCRIPTION
This fleshes out specifications in `v1` of https://cds.cern.ch/record/2728364.